### PR TITLE
API changes for room details

### DIFF
--- a/APIPartials/SparkRooms.cs
+++ b/APIPartials/SparkRooms.cs
@@ -42,6 +42,19 @@ namespace SparkDotNet
         }
 
         /// <summary>
+        /// Shows Webex meeting details for a room such as the SIP address, meeting URL, toll-free and toll dial-in numbers.
+        /// Specify the room ID in the roomId parameter in the URI.
+        /// </summary>
+        /// <param name="roomId"></param>
+        /// <returns>MeetingDetails object.</returns>
+        public async Task<MeetingDetails> GetRoomMeetingDetailsAsync(string roomId)
+        {
+            var queryParams = new Dictionary<string, string>();
+            var path = getURL($"{roomsBase}/{roomId}/meetingInfo", queryParams);
+            return await GetItemAsync<MeetingDetails>(path);
+        }
+
+        /// <summary>
         /// Creates a room. The authenticated user is automatically added as a member of the room. See the Memberships API to learn how to add more people to the room.
         /// </summary>
         /// <param name="title"></param>

--- a/Models/MeetingDetails.cs
+++ b/Models/MeetingDetails.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace SparkDotNet
+{
+    public class MeetingDetails
+    {
+        public string roomId { get; set; }
+        public string meetingLink { get; set; }
+        public string sipAddress { get; set; }
+        public string meetingNumber { get; set; }
+        public string callInTollFreeNumber { get; set; }
+        public string callInTollNumber { get; set; }
+
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
+    }
+}

--- a/Models/Room.cs
+++ b/Models/Room.cs
@@ -13,7 +13,6 @@ namespace SparkDotNet
         public DateTime lastActivity { get; set; }
         public string type { get; set; }
         public string creatorId { get; set; }
-        public string sipAddress { get; set; }
 
         public override string ToString()
         {

--- a/SparkDotNet.csproj
+++ b/SparkDotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.2.4</VersionPrefix>
+    <VersionPrefix>1.2.5</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net461;net45</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>SparkDotNet</AssemblyName>
@@ -9,7 +9,6 @@
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.0</NetStandardImplicitPackageVersion>
     <PackageLicenseUrl>https://github.com/darrenparkinson/SparkDotNet/blob/master/LICENSE</PackageLicenseUrl>
     <Description>An unofficial dotnet library for consuming RESTful APIs for Cisco Spark (now Webex Teams). Please visit Cisco at https://developer.webex.com.</Description>
-    <Version>1.2.4</Version>
     <Authors>Darren Parkinson</Authors>
     <PackageProjectUrl>https://github.com/darrenparkinson/SparkDotNet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Hi

On July 19 Cisco informed that the sipAddress field on the room object i deprecated and will be removed on the September 30 2019. The sipAddress can now be obtained via a separate Room Meeting Details call. I have made the necessary changes.

https://developer.webex.com/docs/api/changelog

Add new model for MeetingDetails
Add new rest call in SparkRooms (GetRoomMeetingDetailsAsync)
Remove sipAddress from Room model